### PR TITLE
Add Shabbat API and refactor parasha fetch

### DIFF
--- a/app/api/shabbat/route.ts
+++ b/app/api/shabbat/route.ts
@@ -1,0 +1,102 @@
+export const dynamic = 'force-dynamic'
+
+import { NextResponse } from 'next/server'
+
+function getNextShabbatDate() {
+  const today = new Date()
+  const dayOfWeek = today.getDay()
+  let daysUntilShabbat = (6 - dayOfWeek + 7) % 7 || 7
+  if (dayOfWeek === 6) {
+    daysUntilShabbat = 7
+  }
+  const nextShabbat = new Date(today)
+  nextShabbat.setDate(today.getDate() + daysUntilShabbat)
+  return nextShabbat.toISOString().slice(0, 10)
+}
+
+export async function GET() {
+  const shabbatDate = getNextShabbatDate()
+  const url = `https://www.hebcal.com/shabbat?cfg=json&geonameid=3469058&start=${shabbatDate}&end=${shabbatDate}`
+  const res = await fetch(url)
+  const data = await res.json()
+
+  const items = Array.isArray((data as Record<string, unknown>)['items'])
+    ? ((data as Record<string, unknown>)['items'] as Record<string, unknown>[])
+    : []
+
+  const parashaEvent = items.find(
+    item =>
+      typeof item === 'object' &&
+      item !== null &&
+      'category' in item &&
+      item['category'] === 'parashat'
+  )
+
+  const haftarahEvent = items.find(
+    item =>
+      typeof item === 'object' &&
+      item !== null &&
+      'category' in item &&
+      item['category'] === 'haftarah'
+  )
+
+  const specialReadings = items.filter(
+    item =>
+      typeof item === 'object' &&
+      item !== null &&
+      'category' in item &&
+      (item['category'] === 'holiday' || item['category'] === 'roshchodesh')
+  )
+
+  let haftarah =
+    haftarahEvent &&
+    typeof haftarahEvent === 'object' &&
+    haftarahEvent !== null &&
+    'title' in haftarahEvent
+      ? (haftarahEvent['title'] as string)
+      : ''
+
+  const leyning =
+    parashaEvent &&
+    typeof parashaEvent === 'object' &&
+    parashaEvent !== null &&
+    'leyning' in parashaEvent
+      ? parashaEvent['leyning']
+      : undefined
+
+  if (
+    !haftarah &&
+    leyning &&
+    typeof leyning === 'object' &&
+    leyning !== null &&
+    'haftarah' in leyning
+  ) {
+    const haft = (leyning as { haftarah?: unknown })['haftarah']
+    if (typeof haft === 'string') {
+      haftarah = haft
+    } else if (haft && typeof haft === 'object' && ('ashkenaz' in haft || 'sephardic' in haft)) {
+      haftarah =
+        (haft as { ashkenaz?: string; sephardic?: string })['ashkenaz'] ||
+        (haft as { ashkenaz?: string; sephardic?: string })['sephardic'] ||
+        ''
+    }
+  }
+
+  const result = {
+    nome:
+      parashaEvent &&
+      typeof parashaEvent === 'object' &&
+      parashaEvent !== null &&
+      'title' in parashaEvent
+        ? (parashaEvent['title'] as string)
+        : 'Parashá não encontrada',
+    haftarah,
+    leituraEspecial: specialReadings
+      .map(item =>
+        typeof item === 'object' && item !== null && 'title' in item ? item['title'] : ''
+      )
+      .join(', '),
+  }
+
+  return NextResponse.json(result)
+}

--- a/app/lib/parasha-semanal.ts
+++ b/app/lib/parasha-semanal.ts
@@ -1,92 +1,11 @@
-import fetch from 'node-fetch'
-
-function getNextShabbatDate() {
-  const today = new Date()
-  const dayOfWeek = today.getDay()
-  let daysUntilShabbat = (6 - dayOfWeek + 7) % 7 || 7
-  // Se hoje for sábado, pega o próximo sábado (da semana que vem)
-  if (dayOfWeek === 6) {
-    daysUntilShabbat = 7
-  }
-  const nextShabbat = new Date(today)
-  nextShabbat.setDate(today.getDate() + daysUntilShabbat)
-  return nextShabbat.toISOString().slice(0, 10)
+function getBaseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  )
 }
 
 export async function getParashaSemanal() {
-  const shabbatDate = getNextShabbatDate()
-  const url = `https://www.hebcal.com/shabbat?cfg=json&geonameid=3469058&start=${shabbatDate}&end=${shabbatDate}`
-  const res = await fetch(url)
-  const data = await res.json()
-  // Extrai a parashá, haftarah e eventos especiais
-  const items = Array.isArray((data as Record<string, unknown>)['items'])
-    ? ((data as Record<string, unknown>)['items'] as Record<string, unknown>[])
-    : []
-  const parashaEvent = items.find(
-    item =>
-      typeof item === 'object' &&
-      item !== null &&
-      'category' in item &&
-      item['category'] === 'parashat'
-  )
-  const haftarahEvent = items.find(
-    item =>
-      typeof item === 'object' &&
-      item !== null &&
-      'category' in item &&
-      item['category'] === 'haftarah'
-  )
-  const specialReadings = items.filter(
-    item =>
-      typeof item === 'object' &&
-      item !== null &&
-      'category' in item &&
-      (item['category'] === 'holiday' || item['category'] === 'roshchodesh')
-  )
-  let haftarah =
-    haftarahEvent &&
-    typeof haftarahEvent === 'object' &&
-    haftarahEvent !== null &&
-    'title' in haftarahEvent
-      ? (haftarahEvent['title'] as string)
-      : ''
-  const leyning =
-    parashaEvent &&
-    typeof parashaEvent === 'object' &&
-    parashaEvent !== null &&
-    'leyning' in parashaEvent
-      ? parashaEvent['leyning']
-      : undefined
-  if (
-    !haftarah &&
-    leyning &&
-    typeof leyning === 'object' &&
-    leyning !== null &&
-    'haftarah' in leyning
-  ) {
-    const haft = (leyning as { haftarah?: unknown })['haftarah']
-    if (typeof haft === 'string') {
-      haftarah = haft
-    } else if (haft && typeof haft === 'object' && ('ashkenaz' in haft || 'sephardic' in haft)) {
-      haftarah =
-        (haft as { ashkenaz?: string; sephardic?: string })['ashkenaz'] ||
-        (haft as { ashkenaz?: string; sephardic?: string })['sephardic'] ||
-        ''
-    }
-  }
-  return {
-    nome:
-      parashaEvent &&
-      typeof parashaEvent === 'object' &&
-      parashaEvent !== null &&
-      'title' in parashaEvent
-        ? (parashaEvent['title'] as string)
-        : 'Parashá não encontrada',
-    haftarah,
-    leituraEspecial: specialReadings
-      .map(item =>
-        typeof item === 'object' && item !== null && 'title' in item ? item['title'] : ''
-      )
-      .join(', '),
-  }
+  const res = await fetch(`${getBaseUrl()}/api/shabbat`)
+  return res.json()
 }


### PR DESCRIPTION
## Summary
- create `/api/shabbat` route to query Hebcal at runtime and disable Next.js caching
- fetch internal API inside `getParashaSemanal`
- use environment variables to build base URL and drop `node-fetch`

## Testing
- `npm test` *(fails: Test Files 118 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685efd05d9b883318b78209a7d18f422