### PR TITLE
Extend environment typing

### DIFF
--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -8,6 +8,10 @@ declare namespace NodeJS {
     NEXT_PUBLIC_SUPABASE_ANON_KEY: string
     SUPABASE_SERVICE_ROLE_KEY: string
 
+    SUPABASE_URL: string
+    VERCEL_URL?: string
+    JWT_SECRET: string
+
     NEXT_PUBLIC_BASE_URL: string
 
     // SMTP


### PR DESCRIPTION
## Summary
- add `SUPABASE_URL`, `VERCEL_URL`, and `JWT_SECRET` to `ProcessEnv`
- run `npm run type-check` (fails: missing type definitions in test files)

## Testing
- `npm run type-check` *(fails: Could not find a declaration file for module 'jest-axe')*

------
https://chatgpt.com/codex/tasks/task_e_685f05bd8d8483318ed71175625bf969